### PR TITLE
restore unique id for inside plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-syntax-highlighter": "^15.6.1",
         "style-to-js": "^1.1.16",
         "typescript": "^5.5.3",
+        "uuid": "^11.1.0",
         "vite": "^5.4.1"
       }
     },
@@ -330,6 +331,19 @@
       "dependencies": {
         "@datocms/rest-client-utils": "^4.0.0",
         "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@datocms/cma-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@datocms/rest-client-utils": {
@@ -3649,16 +3663,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-syntax-highlighter": "^15.6.1",
     "style-to-js": "^1.1.16",
     "typescript": "^5.5.3",
+    "uuid": "^11.1.0",
     "vite": "^5.4.1"
   },
   "eslintConfig": {

--- a/src/entrypoints/variables.ts
+++ b/src/entrypoints/variables.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export const NODE_OPTIONS: CustomStyleNode[] = [
   { label: "Paragraph", value: "paragraph" },
   { label: "Heading", value: "heading" },
@@ -5,7 +7,7 @@ export const NODE_OPTIONS: CustomStyleNode[] = [
 
 export const DUMMY_CUSTOM_STYLE = () => {
   return {
-    id: 'stand-out',
+    id: uuidv4(),
     title: "Stand Out",
     css: `text-align: center;
 font-size: 24px;


### PR DESCRIPTION
Breaking bug of non unique ids.
When submitting data to Dato, the CSS class is used, but inside the plugin itself, it should have a unique id.